### PR TITLE
Add trn deployment pipeline ID to deployment step in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
             elif [ ${{ github.ref }} == 'refs/heads/staging' ]; then
               pipelineId=1286
             elif [ ${{ github.ref }} == 'refs/heads/master' ]; then
-              pipelineId=1233
+              pipelineId=1483,1233
             else
               echo "No pipeline to trigger for ref ${{ github.ref }}"
               exit 0


### PR DESCRIPTION
This pull request includes a change to the CI workflow configuration file to update the pipeline IDs triggered for the `master` branch.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL178-R178): Modified the `pipelineId` for the `master` branch to include both `1483` and `1233`.