### PR TITLE
From email is always needed

### DIFF
--- a/src/hope_country_report/config/__init__.py
+++ b/src/hope_country_report/config/__init__.py
@@ -47,7 +47,7 @@ CONFIG = {
     "DATABASE_HOPE_URL": (str, "", "", True, "HOPE database connection url (forced to be readonly)"),
     "DATABASE_URL": (str, "", "", True, doc_environ("environ-env-db-url")),
     "DEBUG": (bool, False, setting("debug")),
-    "DEFAULT_FROM_EMAIL": (str, ""),
+    "DEFAULT_FROM_EMAIL": (str, NOT_SET, "Default sender email address"),
     "EMAIL_BACKEND": (str, "anymail.backends.mailjet.EmailBackend", "Do not change in prod"),
     "EMAIL_HOST": (str, ""),
     "EMAIL_HOST_PASSWORD": (str, ""),

--- a/src/hope_country_report/utils/mail.py
+++ b/src/hope_country_report/utils/mail.py
@@ -67,6 +67,7 @@ def send_request_access(
     else:
         recipient_list = [report.owner.email]
     email = EmailMessage(
+        to=[settings.DEFAULT_FROM_EMAIL],
         bcc=recipient_list,
         from_email=settings.DEFAULT_FROM_EMAIL,
         subject=f"{sender.full_name} wants to access '{report.title}'",
@@ -100,6 +101,7 @@ def notify_report_completion(report: "ReportConfiguration", request: "AuthHttpRe
         return 0
 
     message = EmailMessage(
+        to=[settings.DEFAULT_FROM_EMAIL],
         from_email=settings.DEFAULT_FROM_EMAIL,
         bcc=recipient_list,
         subject="Report updated/created",

--- a/tests/utils/test_ut_mail.py
+++ b/tests/utils/test_ut_mail.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 from constance.test import override_config
+from django.conf import settings
 
 from hope_country_report.state import state
 from hope_country_report.utils.mail import notify_report_completion, send_document_password, send_request_access
@@ -43,6 +44,7 @@ def test_send_request_access(cfg, expected, mocked_responses, user, report, mail
             assert res == 1
             assert len(mailoutbox) == 1
             assert mailoutbox[0].bcc == [expected]
+            assert mailoutbox[0].to == [settings.DEFAULT_FROM_EMAIL]
 
 
 @pytest.mark.parametrize(
@@ -78,6 +80,7 @@ def test_notify_report_completion(cfg, expected, mocked_responses, user, report:
             assert res == 1
             assert len(mailoutbox) == 1
             assert mailoutbox[0].bcc == [expected]
+            assert mailoutbox[0].to == [settings.DEFAULT_FROM_EMAIL]
 
 
 def test_notify_report_completion_no_recipients(mocked_responses, report, mailoutbox):


### PR DESCRIPTION
1. **Fix Mailjet Recipient Errors:** Set `to=[settings.DEFAULT_FROM_EMAIL]` in `notify_report_completion` and `send_request_access`. This satisfies Mailjet's requirement for a valid
  `To` recipient while preserving the privacy of the actual subscribers who remain hidden in `Bcc`.
2. **Enforce Configuration:** Marked `DEFAULT_FROM_EMAIL` as `NOT_SET` (mandatory) in `src/hope_country_report/config/__init__.py`. The `upgrade` command will now halt deployment
  early if this variable is missing or misconfigured in the environment.
